### PR TITLE
Stop passing an ActivityControllerView as a delegate

### DIFF
--- a/MVPA Workout WatchKit Extension/Activity ControllerView.swift
+++ b/MVPA Workout WatchKit Extension/Activity ControllerView.swift
@@ -18,6 +18,87 @@ struct Constants {
     static let lowerBoundPercentage = 0.5
 }
 
+class ActivitySampleProcessor: NSObject {
+    let workoutManager = WorkoutManager()
+    var hrMax : Int = 10;
+    var bpmValues: [Int] = []
+    var percentageOfGoalComplete: Double = 0
+
+    var targetBPM: Int { Int(Double(hrMax) * Constants.lowerBoundPercentage) }
+    var currentPercentageAboveTargetBPM: Double = 0
+    var aboveTarget = false
+
+    // Sound and notifications
+    let device = WKInterfaceDevice()
+    let center = UNUserNotificationCenter.current()
+
+    var dingTimer = Timer()
+    private var dingCounter = 0
+    var activityColor = Color.darkGrey
+
+
+    func recalculatePercentage(bpm: Int) {
+        self.bpmValues.append(bpm)
+        let samplesAboveTarget: Int = self.bpmValues.reduce(0) {
+            partialResult, bpm in
+            let sampleIsAboveTarget = (Int(bpm) >= targetBPM ? 1 : 0)
+            return partialResult + sampleIsAboveTarget
+        }
+
+        // for the ring
+        self.percentageOfGoalComplete = Double(samplesAboveTarget) / Double(Constants.samplesToReachGoal)
+        print(Double(samplesAboveTarget))
+        print(Double(Constants.samplesToReachGoal))
+        print(percentageOfGoalComplete)
+        print("Goal complate: \(Int(percentageOfGoalComplete * 100))%")
+
+        // for activity success
+        print("samplesAboveTarget: \(samplesAboveTarget), total \(self.bpmValues.count)")
+        self.currentPercentageAboveTargetBPM = Double(samplesAboveTarget) / Double(self.bpmValues.count)
+
+        print("currentPercentageAboveTargetBPM: \(Int(currentPercentageAboveTargetBPM * 100))%")
+    }
+
+    func processSample() {
+        let bpm = Int(workoutManager.heartRate.rounded())
+
+        print("------------------ process sample -----------------------")
+        let hrMaxPercent = Int(Double(bpm) / Double(hrMax) * 100)
+        print("bpm: \(bpm), hrMaxPercent: \(hrMaxPercent)%")
+        recalculatePercentage(bpm: bpm)
+
+        print("aboveTarget \(aboveTarget) targetBPM \(targetBPM)")
+
+        if !aboveTarget && bpm >= targetBPM {
+            aboveTarget = true
+            device.play(.start)
+            center.add(UNNotificationRequest(identifier: "ding",
+                                             content: UNNotificationContent(),
+                                             trigger: nil))
+            activityColor = .green
+
+            // init timer
+
+            dingTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
+                self?.dingCounter += 1
+                if self?.dingCounter == 10 {
+                    self?.device.play(.start)
+                    self?.dingCounter = 0
+                }
+            })
+        } else if (bpm <= targetBPM) {
+            aboveTarget = false
+            activityColor = .darkGrey
+
+            // reset timer
+            dingTimer.invalidate()
+            dingCounter = 0
+        }
+
+        print("done with sample")
+    }
+}
+
 struct ActivityControllerView: View {
     @Binding var workoutDuration: Int
     @Binding var hrMax: Int
@@ -30,33 +111,28 @@ struct ActivityControllerView: View {
     @State var aboveTarget = false
     @State var soundEnabled = false
     @State var circleDiameter: CGFloat = 150
-    
-    @State var currentPercentageAboveTargetBPM: Double = 0
-    @State var bpmValues: [Int] = []
-    
+
     @State var percentageOfGoalComplete: Double = 0
-    
-    @StateObject private var workoutManager = WorkoutManager()
+
     @StateObject private var phoneConnector = PhoneConnector()
-    
-    // Sound and notifications
-    let device = WKInterfaceDevice()
-    let center = UNUserNotificationCenter.current()
-    
 
     @State var dingTimer = Timer()
     @State private var dingCounter = 0
+
+    let processor = ActivitySampleProcessor()
+    var workoutManager : WorkoutManager { self.processor.workoutManager }
     
     //    var model = ConnectivityProvider()
     
     func setUp() -> Void {
         print("request sound permissions")
+        let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.sound]) { granted, error in
             soundEnabled = granted
         }
         
         print("request workout manager permissions")
-        workoutManager.delegate = self
+        workoutManager.delegate = self.processor
         workoutManager.requestAuthorization()
     }
     
@@ -80,8 +156,8 @@ struct ActivityControllerView: View {
         print("targetBPM \(targetBPM)")
 
         // init activity values
-        self.bpmValues = []
-        activityColor = .darkGrey
+        self.processor.bpmValues = []
+        self.processor.activityColor = .darkGrey
         
         activityEngaged = workoutManager.startWorkout(workoutType: .other)
         if (activityEngaged) {
@@ -99,77 +175,17 @@ struct ActivityControllerView: View {
         workoutManager.endWorkout()
                 
         if percentageOfGoalComplete >= 1 {
-            device.play(.success)
+            self.processor.device.play(.success)
             finalColor = .green
         } else {
-            device.play(.failure)
+            self.processor.device.play(.failure)
             finalColor = .darkGrey
         }
     
-        labelText = "\(Int(currentPercentageAboveTargetBPM * 100))%"
+        labelText = "\(Int(self.processor.currentPercentageAboveTargetBPM * 100))%"
         activityEngaged = false
 //        phoneConnector.sendWorkoutData(bpm: 25, averageBpm: 25, hrMaxPercentage: 30)
         print("activity ended acv")
-    }
-    
-    func recalculatePercentage(bpm: Int) {
-        self.bpmValues.append(bpm)
-        let samplesAboveTarget: Int = self.bpmValues.reduce(0) {
-            partialResult, bpm in
-            let sampleIsAboveTarget = (Int(bpm) >= targetBPM ? 1 : 0)
-            return partialResult + sampleIsAboveTarget
-        }
-        
-        // for the ring
-        self.percentageOfGoalComplete = Double(samplesAboveTarget) / Double(Constants.samplesToReachGoal)
-        print(Double(samplesAboveTarget))
-        print(Double(Constants.samplesToReachGoal))
-        print(percentageOfGoalComplete)
-        print("Goal complate: \(Int(percentageOfGoalComplete * 100))%")
-
-        // for activity success
-        print("samplesAboveTarget: \(samplesAboveTarget), total \(self.bpmValues.count)")
-        self.currentPercentageAboveTargetBPM = Double(samplesAboveTarget) / Double(self.bpmValues.count)
-        
-        print("currentPercentageAboveTargetBPM: \(Int(currentPercentageAboveTargetBPM * 100))%")
-    }
-    
-    func processSample() {
-        let bpm = Int(workoutManager.heartRate.rounded())
-        
-        print("------------------ process sample -----------------------")
-        let hrMaxPercent = Int(Double(bpm) / Double(hrMax) * 100)
-        print("bpm: \(bpm), hrMaxPercent: \(hrMaxPercent)%")
-        recalculatePercentage(bpm: bpm)
-        
-        print("aboveTarget \(aboveTarget) targetBPM \(targetBPM)")
-        
-        if !aboveTarget && bpm >= targetBPM {
-            aboveTarget = true
-            device.play(.start)
-            center.add(UNNotificationRequest(identifier: "ding",
-                                             content: UNNotificationContent(),
-                                             trigger: nil))
-            activityColor = .green
-            
-            // init timer
-            dingTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { _ in
-                dingCounter += 1
-                if dingCounter == 10 {
-                    device.play(.start)
-                    dingCounter = 0
-                }
-            })
-        } else if (bpm <= targetBPM) {
-            aboveTarget = false
-            activityColor = .darkGrey
-            
-            // reset timer
-            dingTimer.invalidate()
-            dingCounter = 0
-        }
-        
-        print("done with sample")
     }
     
     func updateColor(value: Int, dst: UnsafeMutablePointer<Color>) {

--- a/MVPA Workout WatchKit Extension/WorkoutManager.swift
+++ b/MVPA Workout WatchKit Extension/WorkoutManager.swift
@@ -12,7 +12,7 @@ import WatchConnectivity
 
 class WorkoutManager: NSObject, ObservableObject {
     
-    var delegate: ActivityControllerView?
+    var delegate: ActivitySampleProcessor?
 //    var selectedWorkout: HKWorkoutActivityType? {
 //        didSet {
 //            guard let selectedWorkout = selectedWorkout else { return }


### PR DESCRIPTION
Prior to this change, WorkoutManager had a ActivityControllerView as a
delegate. However ActivityControllerView is a struct, and therefore setting
it as a delegate will copy the struct by value, leading to strange and
unexpected behavior.

Switch to using a new class ActivitySampleProcessor. The instance of the
class can be shared between ActivityControllerView and the WorkoutManager.

Migrating variables into the class will cause some things to fail to
update; I know very little about SwiftUI so I don't know the best way to
fix these. But this at least correctly stops copying the struct.